### PR TITLE
Modernize CI: update workflows, migrate Pages to Actions, add CLAUDE.md

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,18 +3,23 @@ name: '🚀 Build and Publish Library'
 on:
   release:
     types: [created]
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
       - run: npm ci
+      - run: npm test
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: '🌐 Deploy Example to Pages'
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - name: Install library deps
+        run: npm ci
+      - name: Build library
+        run: npm run build
+      - name: Install example deps
+        working-directory: example
+        run: npm install
+      - name: Build example
+        working-directory: example
+        run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -4,12 +4,16 @@ on: [pull_request]
 
 jobs:
   test:
-    name: 'Testing'
+    name: 'Testing (Node ${{ matrix.node-version }})'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.x', '22.x']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm ci
       - run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- `npm test` — run the Jest suite (config in `jest.config.js`, tests colocated as `*.test.ts` under `src/`).
+- `npx jest src/lib/leapYear.test.ts` — run a single test file. Add `-t "name"` to filter by test name.
+- `npm run build` — parallel dual build: CommonJS (`build/main` via `tsconfig.json`) and ES modules (`build/module` via `tsconfig.module.json`). Both are published; `package.json` `main`/`module`/`typings` point at them.
+- `npm run fix` — Prettier + ESLint autofix over `src/**/*.ts` (also `fix:example` for the demo app).
+- Example app: `cd example && npm run dev` (Vite + React demo consuming the library).
+
+## Architecture
+
+This is a **low-level, configuration-driven** library for fantasy calendars. There is no built-in "current date" — callers own state and query the library for derived information about arbitrary dates.
+
+### Core flow
+
+`RPGCalendar` (`src/RPGCalendar.ts`) is the single public class. Its constructor takes a `RPGCalendarConfig` and uses **builder functions** from `src/lib/` to close over the config once, producing specialized helpers (`isLeapYear`, `getDaysInYear`, `getDaysInMonth`, `getExtraDay`, `getNext/PrevMonthYear`, etc.). Each `src/lib/<name>.ts` exports a `<name>Builder` that returns the closed-over function — this is the pattern to follow when adding calendar behavior. Do not read `this.config` at query time in hot paths; wire a builder in the constructor instead.
+
+Public query methods on `RPGCalendar`:
+- `epochToDate(epoch)` / `dateStringToRPGDate(str)` / `createDate(y, m, d, ...)` — three ways to construct a fully-populated `RPGCalendarDate`.
+- `getDisplayMonth({ year, month })` — returns a `RPGCalendarMonthDisplay` optimized for rendering: `weeks: RPGCalendarDate[][]` (padded leading empty cells when `monthStartOnWeekStart` is false) plus `extraDays: RPGCalendarDate[]` for intercalary days surfaced separately.
+- `getDaySpanFromDate(date)` — start/end `RPGCalendarDate`s covering a whole day, driven by `hoursInDay`/`minutesInHour`/`secondsInMinutes` in the config.
+
+### The epoch model
+
+An **epochDay** is an integer count of days from year `0` (or `1`, depending on `hasYear0`). A **complex epoch string** is `"<epochDay>-hh:mm:ss"`. `epochToDate` walks years then months subtracting days — this is O(years); avoid calling it in tight inner loops for very distant dates.
+
+### Intercalary ("extra") days
+
+`RPGCalendarMonth.extraDays` (config-level `RPGCalendarExtraDay[]`) declares intercalary days appended to a month (e.g. Harptos's Midwinter, Shieldmeet, or Gregorian Feb 29). Some carry `onlyInLeapYear: true`. `getDisplayMonth` deliberately **separates** these from `weeks` — they don't belong to any weekday cell. `getDaysInMonth` includes them in totals when they apply, so `createDate(year, month, daysInMonth + N)` works and `getExtraDay` will resolve them. This split is intentional: don't fold `extraDays` back into `weeks`.
+
+### Leap-year handling
+
+Two mechanisms, checked in this order by `isLeapYearBuilder`:
+1. `config.isLeapYear(year, hasYear0)` override (used by Gregorian since its rule can't be expressed as one interval).
+2. `config.leapYearInterval` — simple `year % interval === 0`.
+
+`hasYear0: false` calendars throw on `year === 0`. Harptos treats year 0 as a leap year for symmetry with negative years; Gregorian does not use year 0.
+
+### Built-in calendars
+
+`src/calendars/` exports two presets via `calendars`:
+- `calendars.harptos.extraDays` / `.extraMonths` / `.standard` (`.standard === .extraDays`) — Forgotten Realms.
+- `calendars.gregorian` — real-world Gregorian, uses `isLeapYear` override.
+
+Each calendar is a folder of small modules (`weekdays.ts`, `months.ts`, `seasons.ts`, `time.ts`, plus a top-level config object). Adding a new calendar means creating a similar folder and exporting it from `src/calendars/index.ts`.
+
+## Conventions
+
+- **Public API surface is `src/index.ts` only.** Anything not re-exported there is internal — consumers should not depend on `lib/*` paths.
+- Builder pattern (see above) — new calendar-derived helpers should follow it rather than being methods that re-read `this.config` each call.
+- Tests are colocated (`foo.ts` + `foo.test.ts`) under `src/`. Integration-style tests for whole calendars live at `src/calendars/<name>/<name>.test.ts`.
+- The `example/` app is a self-contained Vite + React + Zustand demo with its own `package.json` and `node_modules`; it is not part of the library build.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2356,8 +2356,7 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "requires": {}
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "vite": {
       "version": "3.1.0",

--- a/src/RPGCalendar.ts
+++ b/src/RPGCalendar.ts
@@ -295,13 +295,17 @@ export class RPGCalendar {
   // getDaySpanFromDate returns a RPGDateSpan with the min and max (start/end) times for the given day.  This is useful
   // when creating queries or defining an event that lasted for an entire day.
   getDaySpanFromDate(date: RPGCalendarDate): RPGDateSpan {
-    const eh = this.config.hoursInDay - 1;
-    const em = this.config.minutesInHour - 1;
-    const es = this.config.secondsInMinutes - 1;
+    const eh = (this.config.hoursInDay ?? 24) - 1;
+    const em = (this.config.minutesInHour ?? 60) - 1;
+    const es = (this.config.secondsInMinutes ?? 60) - 1;
+
+    const year = date.year ?? 0;
+    const month = date.monthOfYear ?? 1;
+    const day = date.dayOfMonth ?? 1;
 
     return {
-      start: this.createDate(date.year, date.monthOfYear, date.dayOfMonth),
-      end: this.createDate(date.year, date.monthOfYear, date.dayOfMonth, eh, em, es)
+      start: this.createDate(year, month, day),
+      end: this.createDate(year, month, day, eh, em, es)
     };
   }
 }


### PR DESCRIPTION
- build-and-publish: bump to Node 20, actions@v4, npm cache, run tests before publish, add --provenance --access public for supply-chain signing
- pull-request-test: bump to Node 20 + 22 matrix, actions@v4, npm cache
- deploy-pages: new Actions-based Pages workflow that builds the example fresh and deploys via actions/deploy-pages@v4, replacing the flaky legacy Jekyll pipeline
- RPGCalendar.getDaySpanFromDate: guard optional config fields with defaults so strict-mode consumers (like the example app) compile
- CLAUDE.md: architecture and command reference for future Claude Code sessions